### PR TITLE
Bump package version / update sha256sum

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "paper.dash.org",
-  "version": "3.1.0",
-  "sha256sum": "ca37346a9aa5faf87cf9cc4649269186fdf30cf44e7834d83ec9dfeecab2f3a5",
+  "version": "3.1.0-dash",
+  "sha256sum": "61e217ab73a1d74d6de316e8d513fbff8ab0275e9bcf7bf7fc5ac47deab6c21e",
   "description": "Open Source JavaScript Client-Side Dash Wallet Generator",
   "main": "Gruntfile.js",
   "dependencies": {

--- a/paper.dash.org.html
+++ b/paper.dash.org.html
@@ -7024,7 +7024,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 				<div class="tooltip" id="statusprotocolbad">
 					<span class="statuswarn" id="statuslabelprotocolbad">&#9888; Think twice!</span>
 					<span id="statuslabelprotocolbad1">You appear to be running this generator online from a live website. For valuable wallets it is recommended to</span>
-					<a id="statuslabelprotocolbad2" href="https://github.com/dashpay/paper.dash.org/archive/v3.1.0.zip">download</a>
+					<a id="statuslabelprotocolbad2" href="https://github.com/dashpay/paper.dash.org/archive/v3.1.0-dash.zip">download</a>
 					<span id="statuslabelprotocolbad3">the zip file from GitHub and run this generator offline as a local html file.</span>
 					<br /><br /><input type="button" value="OK" class="button" id="statusokprotocolbad" onclick="document.getElementById('statusprotocolbad').style.display = 'none';" />
 				</div>
@@ -7049,7 +7049,7 @@ input[type=checkbox] { position: relative; z-index: 20; }
 					<span class="item"><span id="footerlabeldonations">Donations for original project:</span> <b>1NiNja</b>1bUmhSoTXozBRBEtR8LeF9TGbZBN</span>
 					<span class="item" id="footerlabeltranslatedby"></span>
 					<span class="item"><a href="https://github.com/dashpay/paper.dash.org" target="_blank" id="footerlabelgithub">GitHub Repository</a> 
-						(<a href="https://github.com/dashpay/paper.dash.org/archive/v3.1.0.zip" target="_blank" id="footerlabelgithubzip">zip</a>)</span>
+						(<a href="https://github.com/dashpay/paper.dash.org/archive/v3.1.0-dash.zip" target="_blank" id="footerlabelgithubzip">zip</a>)</span>
 				</div>
 			</div>
 			<div class="copyright">


### PR DESCRIPTION
AFTER this PR will be merged there must be a new github release / tag "v3.1.0-dash" created to make the link actually work.

fixes https://github.com/dashpay/paper.dash.org/commit/417e495130758e35e99c75ae54ab6251081c6570#commitcomment-17005004 reported by @patorsky
